### PR TITLE
Add header for limits.

### DIFF
--- a/src/TinyString.h
+++ b/src/TinyString.h
@@ -2,6 +2,7 @@
 #include <Arduino.h>
 #include <assert.h>
 #include <cstdint>
+#include <limits>
 
 #pragma pack(push, 1)
 


### PR DESCRIPTION
This line `static constexpr size_type npos = std::numeric_limits<size_type>::max();` requires header `<limits>`.